### PR TITLE
Only one local-definition syntax class with both variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Racket-generated files
+compiled/
+doc/
+
+# Editor-generated files
+*~
+\#*
+.\#*
+
+# OS-generated files
+.DS_Store

--- a/main.rkt
+++ b/main.rkt
@@ -10,12 +10,6 @@
 (define-syntax-parser my-begin
   #:track-literals
 
-  [(_ func:local-function-definition rest:expr ...)
-   #'(splicing-let ([func.name
-                     (λ (func.args ...)
-                       func.body ...)])
-       (my-begin rest ...))]
-
   [(_ val:local-definition rest:expr ...)
    #'(splicing-let ([val.name val.value])
        (my-begin rest ...))]

--- a/private/syntax-classes.rkt
+++ b/private/syntax-classes.rkt
@@ -1,21 +1,18 @@
 #lang racket/base
 
-(provide local-function-definition
-         local-definition)
+(provide local-definition)
 
 (require (for-syntax racket/base)
          syntax/parse)
 
-(define-syntax-class local-function-definition
-  #:description "Local function definition"
+(define-syntax-class local-definition
+  #:description "Local definition"
   #:datum-literals (local)
   (pattern
    (local (name:id args:expr ...)
-     body:expr ...)))
-
-(define-syntax-class local-definition
-  #:description "Local definition"
-  #:datum-literals (local)  
+     body:expr ...)
+   #:with value #'(λ (args ...)
+                    body ...))
   (pattern
    (local name:id value:expr)))
 


### PR DESCRIPTION
You can delete the `local-function-definition` case in the main macro by doing this.